### PR TITLE
Set version for maven-eclipse-plugin to 2.10

### DIFF
--- a/lab/pom.xml
+++ b/lab/pom.xml
@@ -172,6 +172,7 @@
                 <!-- Set Project Natures -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
+		<version>2.10</version>
                 <configuration>
                     <downloadSources>true</downloadSources>
                     <downloadJavadocs>true</downloadJavadocs>


### PR DESCRIPTION
Since maven-eclipse-plugin is retired, the version number is <unkown> in IntelliJ, therefore not properly resolved (error). Setting it to 2.10 (latest version) makes the error go away.