### PR TITLE
Align Dining javadoc with solution and all other projects

### DIFF
--- a/lab/10-spring-intro/src/main/java/rewards/Dining.java
+++ b/lab/10-spring-intro/src/main/java/rewards/Dining.java
@@ -4,7 +4,7 @@ import common.datetime.SimpleDate;
 import common.money.MonetaryAmount;
 
 /**
- * A dining event that occurred, representing a charge made to an credit card by a restaurant on a specific date.
+ * A dining event that occurred, representing a charge made to an credit card by a merchant on a specific date.
  * 
  * For a dining to be eligible for reward, the credit card number should map to an account in the reward network. In
  * addition, the merchant number should map to a restaurant in the network.

--- a/lab/12-javaconfig-dependency-injection/src/main/java/rewards/Dining.java
+++ b/lab/12-javaconfig-dependency-injection/src/main/java/rewards/Dining.java
@@ -4,7 +4,7 @@ import common.datetime.SimpleDate;
 import common.money.MonetaryAmount;
 
 /**
- * A dining event that occurred, representing a charge made to an credit card by a restaurant on a specific date.
+ * A dining event that occurred, representing a charge made to an credit card by a merchant on a specific date.
  * 
  * For a dining to be eligible for reward, the credit card number should map to an account in the reward network. In
  * addition, the merchant number should map to a restaurant in the network.


### PR DESCRIPTION
Using the same javadoc like all the other Dining classes. This makes the classes not showing up when you compare the projects in your IDE.