### PR TITLE
Create external config class in 40-boot-test to avoid creating repos

### DIFF
--- a/lab/40-boot-test-solution/src/main/java/accounts/BootTestSolutionApplication.java
+++ b/lab/40-boot-test-solution/src/main/java/accounts/BootTestSolutionApplication.java
@@ -10,8 +10,6 @@ import org.springframework.context.annotation.Import;
  * Runs the Account Server.
  */
 @SpringBootApplication
-@Import(AppConfig.class)
-@EntityScan("rewards.internal")
 public class BootTestSolutionApplication {
 
 	public static void main(String[] args) {

--- a/lab/40-boot-test-solution/src/test/java/accounts/web/AccountControllerBootTests.java
+++ b/lab/40-boot-test-solution/src/test/java/accounts/web/AccountControllerBootTests.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import rewards.internal.account.Account;
@@ -29,8 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * These tests run the AccountController using the MockMVC framework.
  * The server does not need to be running.
  */
-@WebMvcTest(AccountController.class) // WebMvcTest = MockMvc, @MockBean // JPA: @MockBeans
-@MockBeans({@MockBean(EntityManagerFactory.class), @MockBean(DataSource.class)})
+@WebMvcTest(AccountController.class) // WebMvcTest = MockMvc, @MockBean
 public class AccountControllerBootTests {
 
     @Autowired

--- a/lab/40-boot-test/src/main/java/accounts/BootTestApplication.java
+++ b/lab/40-boot-test/src/main/java/accounts/BootTestApplication.java
@@ -11,8 +11,6 @@ import config.AppConfig;
  * Runs the Account Server.
  */
 @SpringBootApplication
-@Import(AppConfig.class)
-@EntityScan("rewards.internal")
 public class BootTestApplication {
 
 	public static void main(String[] args) {

--- a/lab/40-boot-test/src/main/java/accounts/RewardsConfig.java
+++ b/lab/40-boot-test/src/main/java/accounts/RewardsConfig.java
@@ -1,0 +1,14 @@
+package accounts;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import config.AppConfig;
+
+@Configuration
+@Import(AppConfig.class)
+@EntityScan("rewards.internal")
+public class RewardsConfig {
+
+}

--- a/lab/40-boot-test/src/test/java/accounts/web/AccountControllerBootTests.java
+++ b/lab/40-boot-test/src/test/java/accounts/web/AccountControllerBootTests.java
@@ -13,9 +13,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 //import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 //import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-// TODO-07: Replace @ExtendWith(SpringExtension.class) with the following two annotations
+// TODO-07: Replace @ExtendWith(SpringExtension.class) with the following annotation
 // - @WebMvcTest(AccountController.class) // includes @ExtendWith(SpringExtension.class)
-// - @MockBeans({@MockBean(EntityManagerFactory.class), @MockBean(DataSource.class)})
 @ExtendWith(SpringExtension.class)
 public class AccountControllerBootTests {
 


### PR DESCRIPTION
The current lab mocks data access specific components ( `DataSource` and `EntityManagerFactory `) in the web slice test. 

This is because Spring Boot’s @*Test annotations search for the primary configuration automatically whenever you do not explicitly define one. This makes the `@WebMvcTest` pick the class annotated with `@SpringBootApplcation`. Even if slice tests disable component scanning for configuration classes, our main class imports `AppConfig.class` explicitly, which makes the repositories initialize. The repositories require a `DataSource` and the `EntityManagerFactory `.

This PR moves the import and entity scanning to its own config class. This approach is clearer as we won't have mock data access specific components in the test and matches what the documentation says:

> If you use a [test annotation to test a more specific slice of your application](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.testing.spring-boot-applications.autoconfigured-tests), you should avoid adding configuration settings that are specific to a particular area on the [main method’s application class](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.testing.spring-boot-applications.user-configuration-and-slicing).