### PR TITLE
Update Spring Security lab

### DIFF
--- a/lab/42-security-rest-solution/src/main/java/accounts/RestWsApplication.java
+++ b/lab/42-security-rest-solution/src/main/java/accounts/RestWsApplication.java
@@ -1,10 +1,11 @@
 package accounts;
 
-import config.RestSecurityConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Import;
+
+import config.RestSecurityConfig;
 
 @SpringBootApplication
 @Import(RestSecurityConfig.class)
@@ -12,7 +13,6 @@ import org.springframework.context.annotation.Import;
 public class RestWsApplication {
 
     public static void main(String[] args) {
-
         SpringApplication.run(RestWsApplication.class, args);
     }
 

--- a/lab/42-security-rest-solution/src/main/java/accounts/security/CustomAuthenticationProvider.java
+++ b/lab/42-security-rest-solution/src/main/java/accounts/security/CustomAuthenticationProvider.java
@@ -1,0 +1,38 @@
+package accounts.security;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+//@Component
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+      String username = authentication.getName();
+      String password = authentication.getCredentials().toString();
+
+      if (!checkCustomAuthenticationSystem(username, password)) {
+      	throw new BadCredentialsException("Bad credentials provided");
+      }
+      
+      return new UsernamePasswordAuthenticationToken(
+              username, password, AuthorityUtils.createAuthorityList("ROLE_ADMIN"));
+  }
+
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+      return authentication.equals(UsernamePasswordAuthenticationToken.class);
+  }
+
+  // Use custom authentication system for the verification of the
+  // passed username and password.  (Here we are just faking it.)
+  private boolean checkCustomAuthenticationSystem(String username, String password) {
+      return username.equals("spring") && password.equals("spring");
+  }
+}

--- a/lab/42-security-rest-solution/src/main/java/accounts/security/CustomUserDetailsService.java
+++ b/lab/42-security-rest-solution/src/main/java/accounts/security/CustomUserDetailsService.java
@@ -1,0 +1,37 @@
+package accounts.security;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+//@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private PasswordEncoder passwordEncoder;
+
+    public CustomUserDetailsService(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User.UserBuilder builder = User.builder();
+        builder.username(username);
+        builder.password(passwordEncoder.encode(username));
+        
+        switch (username) {
+            case "mary":
+                builder.roles("USER");
+                break;
+            case "joe":
+                builder.roles("USER", "ADMIN");
+                break;
+            default:
+                throw new UsernameNotFoundException("User not found.");
+        }
+
+        return builder.build();
+    }
+}

--- a/lab/42-security-rest-solution/src/main/java/accounts/security/CustomUserDetailsService.java
+++ b/lab/42-security-rest-solution/src/main/java/accounts/security/CustomUserDetailsService.java
@@ -1,5 +1,7 @@
 package accounts.security;
 
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -7,6 +9,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 //@Component
+@Primary
 public class CustomUserDetailsService implements UserDetailsService {
 
     private PasswordEncoder passwordEncoder;

--- a/lab/42-security-rest-solution/src/main/java/accounts/services/AccountService.java
+++ b/lab/42-security-rest-solution/src/main/java/accounts/services/AccountService.java
@@ -12,8 +12,7 @@ import java.util.stream.Collectors;
 @Service
 public class AccountService {
 
-    @PreAuthorize("hasRole('ADMIN')   && " +
-            "#username == principal.username")
+    @PreAuthorize("hasRole('ADMIN') && #username == principal.username")
     public List<String> getAuthoritiesForUser(String username) {
 
         Collection<? extends GrantedAuthority> grantedAuthorities
@@ -22,7 +21,7 @@ public class AccountService {
                                        .getAuthorities();
 
         return grantedAuthorities.stream()
-                                 .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                 .map(GrantedAuthority::getAuthority)
                                  .collect(Collectors.toList());
     }
 

--- a/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
@@ -24,11 +24,11 @@ public class RestSecurityConfig {
 
         // @formatter:off
         http.authorizeHttpRequests((authz) -> authz
-                .mvcMatchers(HttpMethod.GET, "/accounts/**").hasAnyRole("USER", "ADMIN", "SUPERADMIN")
-                .mvcMatchers(HttpMethod.PUT, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
-                .mvcMatchers(HttpMethod.POST, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
-                .mvcMatchers(HttpMethod.DELETE, "/accounts/**").hasAnyRole("SUPERADMIN")
-                .mvcMatchers("/**").authenticated())
+                .requestMatchers(HttpMethod.GET, "/accounts/**").hasAnyRole("USER", "ADMIN", "SUPERADMIN")
+                .requestMatchers(HttpMethod.PUT, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
+                .requestMatchers(HttpMethod.POST, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/accounts/**").hasAnyRole("SUPERADMIN")
+                .anyRequest().denyAll())
             .httpBasic(withDefaults())
             .csrf(CsrfConfigurer::disable);
         // @formatter:on

--- a/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
@@ -28,6 +28,7 @@ public class RestSecurityConfig {
                 .requestMatchers(HttpMethod.PUT, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
                 .requestMatchers(HttpMethod.POST, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
                 .requestMatchers(HttpMethod.DELETE, "/accounts/**").hasAnyRole("SUPERADMIN")
+                .requestMatchers(HttpMethod.GET, "/authorities").hasAnyRole("USER", "ADMIN", "SUPERADMIN")
                 .anyRequest().denyAll())
             .httpBasic(withDefaults())
             .csrf(CsrfConfigurer::disable);

--- a/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest-solution/src/main/java/config/RestSecurityConfig.java
@@ -1,128 +1,53 @@
 package config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableWebSecurity  // Redundant in Spring Boot app
-@EnableGlobalMethodSecurity(prePostEnabled = true)
-public class RestSecurityConfig extends WebSecurityConfigurerAdapter {
+@EnableMethodSecurity
+public class RestSecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+	@Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         // @formatter:off
-        http.authorizeRequests()
+        http.authorizeHttpRequests((authz) -> authz
                 .mvcMatchers(HttpMethod.GET, "/accounts/**").hasAnyRole("USER", "ADMIN", "SUPERADMIN")
                 .mvcMatchers(HttpMethod.PUT, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
                 .mvcMatchers(HttpMethod.POST, "/accounts/**").hasAnyRole("ADMIN", "SUPERADMIN")
                 .mvcMatchers(HttpMethod.DELETE, "/accounts/**").hasAnyRole("SUPERADMIN")
-                .mvcMatchers("/**").authenticated()
-                .and()
-            .httpBasic()
-                .and()
-            .csrf().disable();
+                .mvcMatchers("/**").authenticated())
+            .httpBasic(withDefaults())
+            .csrf(CsrfConfigurer::disable);
         // @formatter:on
+        
+        return http.build();
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+	@Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) {
+    	
+        UserDetails user = User.withUsername("user").password(passwordEncoder.encode("user")).roles("USER").build();
+        UserDetails admin = User.withUsername("admin").password(passwordEncoder.encode("admin")).roles("USER", "ADMIN").build();
+        UserDetails superadmin = User.withUsername("superadmin").password(passwordEncoder.encode("superadmin")).roles("USER", "ADMIN", "SUPERADMIN").build();
 
-        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
-
-        auth.inMemoryAuthentication()
-            .withUser("user").password(passwordEncoder.encode("user")).roles("USER").and()
-            .withUser("admin").password(passwordEncoder.encode("admin")).roles("USER", "ADMIN").and()
-            .withUser("superadmin").password(passwordEncoder.encode("superadmin")).roles("USER", "ADMIN", "SUPERADMIN");
-
-        // Add authentication based upon the custom UserDetailsService
-        auth.userDetailsService(new CustomUserDetailsService(passwordEncoder));
-
-        // Add authentication based upon the custom AuthenticationProvider
-        auth.authenticationProvider(new CustomAuthenticationProvider());
-
+       return new InMemoryUserDetailsManager(user, admin, superadmin);
     }
-
-}
-
-class CustomUserDetailsService implements UserDetailsService {
-
-    private PasswordEncoder passwordEncoder;
-
-    public CustomUserDetailsService(PasswordEncoder passwordEncoder) {
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User.UserBuilder builder = User.builder();
-        builder.username(username);
-        builder.password(passwordEncoder.encode(username));
-        switch (username) {
-            case "mary":
-                builder.roles("USER");
-                break;
-            case "joe":
-                builder.roles("USER", "ADMIN");
-                break;
-            default:
-                throw new UsernameNotFoundException("User not found.");
-        }
-
-        return builder.build();
-    }
-}
-
-class CustomAuthenticationProvider implements AuthenticationProvider {
-
-    @Override
-    public Authentication authenticate(Authentication authentication)
-            throws AuthenticationException {
-
-        String username = authentication.getName();
-        String password = authentication.getCredentials().toString();
-
-        if (checkCustomAuthenticationSystem(username, password)) {
-
-            return new UsernamePasswordAuthenticationToken(
-                    username, password, new ArrayList<>(Arrays.asList(new GrantedAuthority() {
-                @Override
-                public String getAuthority() {
-                    return "ROLE_ADMIN";
-                }
-            })));
-        } else {
-            return null;
-        }
-    }
-
-    @Override
-    public boolean supports(Class<?> authentication) {
-        return authentication.equals(UsernamePasswordAuthenticationToken.class);
-    }
-
-    // Use custom authentication system for the verification of the
-    // passed username and password.  (Here we are just faking it.)
-    private boolean checkCustomAuthenticationSystem(String username, String password) {
-        return username.equals("spring") && password.equals("spring");
+    
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+    	return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/lab/42-security-rest-solution/src/test/java/accounts/services/AccountServiceMethodSecurityTest.java
+++ b/lab/42-security-rest-solution/src/test/java/accounts/services/AccountServiceMethodSecurityTest.java
@@ -1,6 +1,7 @@
 package accounts.services;
 
-import accounts.RestWsApplication;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -9,10 +10,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import static org.assertj.core.api.Assertions.*;
-
-@SpringBootTest(classes = {RestWsApplication.class},
-        webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class AccountServiceMethodSecurityTest {
 
     @Autowired

--- a/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerCustomAuthenticationProviderTests.java
+++ b/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerCustomAuthenticationProviderTests.java
@@ -1,28 +1,31 @@
 package accounts.web;
 
-import accounts.AccountManager;
-import accounts.RestWsApplication;
-import accounts.services.AccountService;
-import config.RestSecurityConfig;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
+import accounts.AccountManager;
+import accounts.RestWsApplication;
+import accounts.security.CustomAuthenticationProvider;
+import accounts.services.AccountService;
+import config.RestSecurityConfig;
 import rewards.internal.account.Account;
 
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
-@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
+@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class, CustomAuthenticationProvider.class})
 public class AccountControllerCustomAuthenticationProviderTests {
 
     @Autowired
@@ -35,14 +38,14 @@ public class AccountControllerCustomAuthenticationProviderTests {
     private AccountService accountService;
 
     @Test
-    @WithMockUser(username = "spring", password = "spring")
     public void accountDetails_with_spring_credentials_should_return_200() throws Exception {
 
         // arrange
         given(accountManager.getAccount(0L)).willReturn(new Account("1234567890", "John Doe"));
 
         // act and assert
-        mockMvc.perform(get("/accounts/0")).andExpect(status().isOk())
+        mockMvc.perform(get("/accounts/0").with(httpBasic("spring", "spring")))
+               .andExpect(status().isOk())
                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                .andExpect(jsonPath("name").value("John Doe")).andExpect(jsonPath("number").value("1234567890"));
 

--- a/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerCustomUserDetailsServiceTests.java
+++ b/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerCustomUserDetailsServiceTests.java
@@ -1,28 +1,30 @@
 package accounts.web;
 
-import accounts.AccountManager;
-import accounts.RestWsApplication;
-import accounts.services.AccountService;
-import config.RestSecurityConfig;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
+import accounts.AccountManager;
+import accounts.RestWsApplication;
+import accounts.security.CustomUserDetailsService;
+import accounts.services.AccountService;
+import config.RestSecurityConfig;
 import rewards.internal.account.Account;
 
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
-@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
+@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class, CustomUserDetailsService.class})
 public class AccountControllerCustomUserDetailsServiceTests {
 
     @Autowired
@@ -35,7 +37,7 @@ public class AccountControllerCustomUserDetailsServiceTests {
     private AccountService accountService;
 
     @Test
-    @WithMockUser(username = "joe", password = "joe")
+    @WithUserDetails("joe")
     public void accountDetails_with_joe_credentials_should_return_200() throws Exception {
 
         // arrange
@@ -52,7 +54,7 @@ public class AccountControllerCustomUserDetailsServiceTests {
     }
 
     @Test
-    @WithMockUser(username = "mary", password = "mary")
+    @WithUserDetails("mary")
     public void accountDetails_with_mary_credentials_should_return_200() throws Exception {
 
         // arrange

--- a/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerTests.java
+++ b/lab/42-security-rest-solution/src/test/java/accounts/web/AccountControllerTests.java
@@ -1,32 +1,37 @@
 package accounts.web;
 
-import accounts.AccountManager;
-import accounts.RestWsApplication;
-import accounts.services.AccountService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import common.money.Percentage;
-import config.RestSecurityConfig;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import accounts.AccountManager;
+import accounts.RestWsApplication;
+import accounts.services.AccountService;
+import common.money.Percentage;
+import config.RestSecurityConfig;
 import rewards.internal.account.Account;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
 @ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
 public class AccountControllerTests {

--- a/lab/42-security-rest/src/main/java/accounts/RestWsApplication.java
+++ b/lab/42-security-rest/src/main/java/accounts/RestWsApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 // - Configuring authorization based on roles
 // - Configuring authentication using in-memory storage
 // - Configuring method-level security
-// - Adding custom UserDetails
+// - Adding custom UserDetailsService
 // - Adding custom AuthenticationProvider
 // - Writing test code for security
 
@@ -36,14 +36,13 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 //   and observe a successful response
 
 @SpringBootApplication
-// TODO-03: Import security configuration class
-// - Uncomment the line below and go to RestSecurityConfig class
+//TODO-03: Import security configuration class
+//- Uncomment the line below and go to RestSecurityConfig class
 //@Import(RestSecurityConfig.class)
 @EntityScan("rewards.internal")
 public class RestWsApplication {
 
     public static void main(String[] args) {
-
         SpringApplication.run(RestWsApplication.class, args);
     }
 

--- a/lab/42-security-rest/src/main/java/accounts/security/CustomAuthenticationProvider.java
+++ b/lab/42-security-rest/src/main/java/accounts/security/CustomAuthenticationProvider.java
@@ -13,10 +13,9 @@ import org.springframework.security.core.authority.AuthorityUtils;
 //AuthenticationProvider handles a user with the following credentials
 //- "spring"/"spring" with "ROLE_ADMIN" role
 
-//TODO-18a (Optional): Add authentication based upon the custom
-		// AuthenticationProvider
-		// - Uncomment the line below and finish up the code
-		// auth.
+//TODO-18a (Optional): Add authentication based upon the custom AuthenticationProvider
+//- Annotate the class with @Component to make it a Spring manager bean
+
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 
 	@Override

--- a/lab/42-security-rest/src/main/java/accounts/security/CustomAuthenticationProvider.java
+++ b/lab/42-security-rest/src/main/java/accounts/security/CustomAuthenticationProvider.java
@@ -1,0 +1,48 @@
+package accounts.security;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+//TODO-17 (Optional): Create custom AuthenticationProvider
+//- Note that it needs to implement AuthenticationProvider interface
+//- Uncomment the commented code fragment below so that this custom
+//AuthenticationProvider handles a user with the following credentials
+//- "spring"/"spring" with "ROLE_ADMIN" role
+
+//TODO-18a (Optional): Add authentication based upon the custom
+		// AuthenticationProvider
+		// - Uncomment the line below and finish up the code
+		// auth.
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+	@Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+//	    String username = authentication.getName();
+//	    String password = authentication.getCredentials().toString();
+//
+//	    if (!checkCustomAuthenticationSystem(username, password)) {
+//	    	throw new BadCredentialsException("Bad credentials provided");
+//	    }
+//	      
+//	    return new UsernamePasswordAuthenticationToken(
+//	              username, password, AuthorityUtils.createAuthorityList("ROLE_ADMIN"));
+
+		return null; // remove this line
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authentication.equals(UsernamePasswordAuthenticationToken.class);
+	}
+
+	// Use custom authentication system for the verification of the
+	// passed username and password. (Here we are just faking it.)
+	private boolean checkCustomAuthenticationSystem(String username, String password) {
+		return username.equals("spring") && password.equals("spring");
+	}
+}

--- a/lab/42-security-rest/src/main/java/accounts/security/CustomUserDetailsService.java
+++ b/lab/42-security-rest/src/main/java/accounts/security/CustomUserDetailsService.java
@@ -1,0 +1,50 @@
+package accounts.security;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+//Optional exercise - Do the remaining steps only if you have extra time
+//TODO-13 (Optional): Create custom UserDetailsService
+//- Note that it needs to implement loadUserByUsername method
+//of the UserDetailsService interface
+//- Uncomment the commented code fragment below so that this custom
+//UserDetailsService maintains UserDetails of two users:
+//- "mary"/"mary" with "USER" role and
+//- "joe"/"joe" with "USER" and "ADMIN" roles
+
+//TODO-14a (Optional): Add authentication based upon the custom UserDetailsService
+//- Annotate the class with @Component to make it a Spring manager bean
+
+//TODO-18b (Optional): Remove the CustomUserDetailsService definition
+// - Comment the @Component annotation added in a previous task
+
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private PasswordEncoder passwordEncoder;
+
+	public CustomUserDetailsService(PasswordEncoder passwordEncoder) {
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User.UserBuilder builder = User.builder();
+//     builder.username(username);
+//     builder.password(passwordEncoder.encode(username));
+//     switch (username) {
+//         case "mary":
+//             builder.roles("USER");
+//             break;
+//         case "joe":
+//             builder.roles("USER", "ADMIN");
+//             break;
+//         default:
+//             throw new UsernameNotFoundException("User not found.");
+//     }
+
+		return builder.build();
+	}
+}

--- a/lab/42-security-rest/src/main/java/accounts/security/CustomUserDetailsService.java
+++ b/lab/42-security-rest/src/main/java/accounts/security/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package accounts.security;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -21,6 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 //TODO-18b (Optional): Remove the CustomUserDetailsService definition
 // - Comment the @Component annotation added in a previous task
 
+@Primary
 public class CustomUserDetailsService implements UserDetailsService {
 
 	private PasswordEncoder passwordEncoder;

--- a/lab/42-security-rest/src/main/java/accounts/services/AccountService.java
+++ b/lab/42-security-rest/src/main/java/accounts/services/AccountService.java
@@ -39,7 +39,7 @@ public class AccountService {
                 = null; // Modify this line
 
         return grantedAuthorities.stream()
-                                 .map(grantedAuthority -> grantedAuthority.getAuthority())
+                                 .map(GrantedAuthority::getAuthority)
                                  .collect(Collectors.toList());
     }
 

--- a/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
@@ -32,8 +32,8 @@ public class RestSecurityConfig {
                 // - Allow GET on the /accounts resource (or any sub-resource)
                 //   for all roles - "USER", "ADMIN", "SUPERADMIN"
 
-                // For all other URL's, make sure the caller is authenticated
-                .mvcMatchers("/**").authenticated())
+                // Deny any request that doesn't match any authorization rule
+                .anyRequest().denyAll())
         .httpBasic(withDefaults())
         .csrf(CsrfConfigurer::disable);
         // @formatter:on

--- a/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
@@ -24,12 +24,14 @@ public class RestSecurityConfig {
 
 		// @formatter:off
         http.authorizeHttpRequests((authz) -> authz
-                // TODO-04: Configure authorization using mvcMatchers method
+                // TODO-04: Configure authorization using requestMatchers method
                 // - Allow DELETE on the /accounts resource (or any sub-resource)
                 //   for "SUPERADMIN" role only
                 // - Allow POST or PUT on the /accounts resource (or any sub-resource)
                 //   for "ADMIN" or "SUPERADMIN" role only
                 // - Allow GET on the /accounts resource (or any sub-resource)
+                //   for all roles - "USER", "ADMIN", "SUPERADMIN"
+        		// - Allow GET on the /authorities resource
                 //   for all roles - "USER", "ADMIN", "SUPERADMIN"
 
                 // Deny any request that doesn't match any authorization rule

--- a/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
+++ b/lab/42-security-rest/src/main/java/config/RestSecurityConfig.java
@@ -1,33 +1,29 @@
 package config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
-// TODO-10: Enable global method security
-// - Add @EnableGlobalMethodSecurity(prePostEnabled = true)
-//   annotation to this class
+// TODO-10: Enable method security
+// - Add @EnableMethodSecurity annotation to this class
 
 @Configuration
-@EnableWebSecurity      // Redundant in Spring Boot app
-public class RestSecurityConfig extends WebSecurityConfigurerAdapter {
+public class RestSecurityConfig {
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http.authorizeRequests()
+		// @formatter:off
+        http.authorizeHttpRequests((authz) -> authz
                 // TODO-04: Configure authorization using mvcMatchers method
                 // - Allow DELETE on the /accounts resource (or any sub-resource)
                 //   for "SUPERADMIN" role only
@@ -37,109 +33,33 @@ public class RestSecurityConfig extends WebSecurityConfigurerAdapter {
                 //   for all roles - "USER", "ADMIN", "SUPERADMIN"
 
                 // For all other URL's, make sure the caller is authenticated
-                .mvcMatchers("/**").authenticated()
-                .and()
-            .httpBasic()
-                .and()
-            .csrf().disable();
-    }
+                .mvcMatchers("/**").authenticated())
+        .httpBasic(withDefaults())
+        .csrf(CsrfConfigurer::disable);
+        // @formatter:on
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        return http.build();
+	}
 
-        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	// TODO-14b (Optional): Remove the InMemoryUserDetailsManager definition
+	// - Comment the @Bean annotation below
+	
+	@Bean
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) {
 
-        // TODO-05: Add three users with corresponding roles:
-        // - "user"/"user" with "USER" role (example code is provided below)
-        // - "admin"/"admin" with "USER" and "ADMIN" roles
-        // - "superadmin"/"superadmin" with "USER", "ADMIN", and "SUPERADMIN" roles
-        // (Make sure to store the password in encoded form.)
-        auth.inMemoryAuthentication()
-            .withUser("user").password(passwordEncoder.encode("user")).roles("USER").and();
+		// TODO-05: Add three users with corresponding roles:
+		// - "user"/"user" with "USER" role (example code is provided below)
+		// - "admin"/"admin" with "USER" and "ADMIN" roles
+		// - "superadmin"/"superadmin" with "USER", "ADMIN", and "SUPERADMIN" roles
+		// (Make sure to store the password in encoded form.)
+    	// - pass all users in the InMemoryUserDetailsManager constructor
+		UserDetails user = User.withUsername("user").password(passwordEncoder.encode("user")).roles("USER").build();
 
-        // TODO-14 (Optional): Add authentication based upon the custom UserDetailsService
-        // - Uncomment the line below and finish up the code
-        //auth.
-
-        // TODO-18 (Optional): Add authentication based upon the custom AuthenticationProvider
-        // - Uncomment the line below and finish up the code
-        //auth.
-    }
-
-}
-
-// Optional exercise - Do the remaining steps only if you have extra time
-// TODO-13 (Optional): Create custom UserDetailsService
-// - Note that it needs to implement loadUserByUsername method
-//   of the UserDetailsService interface
-// - Uncomment the commented code fragment below so that this custom
-//   UserDetailsService maintains UserDetails of two users:
-//   - "mary"/"mary" with "USER" role and
-//   - "joe"/"joe" with "USER" and "ADMIN" roles
-class CustomUserDetailsService implements UserDetailsService {
-
-    private PasswordEncoder passwordEncoder;
-
-    public CustomUserDetailsService(PasswordEncoder passwordEncoder) {
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User.UserBuilder builder = User.builder();
-//        builder.username(username);
-//        builder.password(passwordEncoder.encode(username));
-//        switch (username) {
-//            case "mary":
-//                builder.roles("USER");
-//                break;
-//            case "joe":
-//                builder.roles("USER", "ADMIN");
-//                break;
-//            default:
-//                throw new UsernameNotFoundException("User not found.");
-//        }
-
-        return builder.build();
-    }
-}
-// TODO-17 (Optional): Create custom AuthenticationProvider
-// - Note that it needs to implement AuthenticationProvider interface
-// - Uncomment the commented code fragment below so that this custom
-//   AuthenticationProvider handles a user with the following credentials
-//   - "spring"/"spring" with "ROLE_ADMIN" role
-class CustomAuthenticationProvider implements AuthenticationProvider {
-
-    @Override
-    public Authentication authenticate(Authentication authentication)
-            throws AuthenticationException {
-
-//        String username = authentication.getName();
-//        String password = authentication.getCredentials().toString();
-//
-//        if (checkCustomAuthenticationSystem(username, password)) {
-//
-//            return new UsernamePasswordAuthenticationToken(
-//                    username, password, new ArrayList<>(Arrays.asList(new GrantedAuthority() {
-//                @Override
-//                public String getAuthority() {
-//                    return "ROLE_ADMIN";
-//                }
-//            })));
-//        } else {
-//            return null;
-//        }
-        return null;   // remove this line
-    }
-
-    @Override
-    public boolean supports(Class<?> authentication) {
-        return authentication.equals(UsernamePasswordAuthenticationToken.class);
-    }
-
-    // Use custom authentication system for the verification of the
-    // passed username and password.  (Here we are just faking it.)
-    private boolean checkCustomAuthenticationSystem(String username, String password) {
-        return username.equals("spring") && password.equals("spring");
+		return new InMemoryUserDetailsManager(user /* Add new users comma-separated here */);
+	}
+    
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+    	return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/lab/42-security-rest/src/test/java/accounts/services/AccountServiceMethodSecurityTest.java
+++ b/lab/42-security-rest/src/test/java/accounts/services/AccountServiceMethodSecurityTest.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.*;
 // - Remove @Disabled annotation from each test and run it
 // - Make sure all tests pass
 
-@SpringBootTest(classes = {RestWsApplication.class},
-        webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class AccountServiceMethodSecurityTest {
 
     @Autowired

--- a/lab/42-security-rest/src/test/java/accounts/web/AccountControllerCustomAuthenticationProviderTests.java
+++ b/lab/42-security-rest/src/test/java/accounts/web/AccountControllerCustomAuthenticationProviderTests.java
@@ -2,6 +2,7 @@ package accounts.web;
 
 import accounts.AccountManager;
 import accounts.RestWsApplication;
+import accounts.security.CustomAuthenticationProvider;
 import accounts.services.AccountService;
 import config.RestSecurityConfig;
 import org.junit.jupiter.api.Disabled;
@@ -18,6 +19,7 @@ import rewards.internal.account.Account;
 
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,9 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // - Remove @Disabled annotation from the test and run it
 // - Make sure the test passes
 
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
-@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
+@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class, CustomAuthenticationProvider.class})
 public class AccountControllerCustomAuthenticationProviderTests {
 
     @Autowired
@@ -42,14 +43,14 @@ public class AccountControllerCustomAuthenticationProviderTests {
 
     @Test
     @Disabled
-    @WithMockUser(username = "spring", password = "spring")
     public void accountDetails_with_spring_credentials_should_return_200() throws Exception {
 
         // arrange
         given(accountManager.getAccount(0L)).willReturn(new Account("1234567890", "John Doe"));
 
         // act and assert
-        mockMvc.perform(get("/accounts/0")).andExpect(status().isOk())
+        mockMvc.perform(get("/accounts/0").with(httpBasic("spring", "spring")))
+               .andExpect(status().isOk())
                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                .andExpect(jsonPath("name").value("John Doe")).andExpect(jsonPath("number").value("1234567890"));
 

--- a/lab/42-security-rest/src/test/java/accounts/web/AccountControllerCustomUserDetailsServiceTests.java
+++ b/lab/42-security-rest/src/test/java/accounts/web/AccountControllerCustomUserDetailsServiceTests.java
@@ -1,25 +1,29 @@
 package accounts.web;
 
-import accounts.AccountManager;
-import accounts.RestWsApplication;
-import accounts.services.AccountService;
-import config.RestSecurityConfig;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import rewards.internal.account.Account;
 
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import accounts.AccountManager;
+import accounts.RestWsApplication;
+import accounts.security.CustomUserDetailsService;
+import accounts.services.AccountService;
+import config.RestSecurityConfig;
+import rewards.internal.account.Account;
 
 // TODO-16 (Optional): Perform security testing for the two users added
 //          through custom UserDetailsService
@@ -27,9 +31,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // - Remove @Disabled annotation from each test and run it
 // - Make sure all tests pass
 
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
-@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
+@ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class, CustomUserDetailsService.class})
 public class AccountControllerCustomUserDetailsServiceTests {
 
     @Autowired
@@ -43,7 +46,7 @@ public class AccountControllerCustomUserDetailsServiceTests {
 
     @Test
     @Disabled
-    @WithMockUser(username = "joe", password = "joe")
+    @WithUserDetails("joe")
     public void accountDetails_with_joe_credentials_should_return_200() throws Exception {
 
         // arrange
@@ -61,7 +64,7 @@ public class AccountControllerCustomUserDetailsServiceTests {
 
     @Test
     @Disabled
-    @WithMockUser(username = "mary", password = "mary")
+    @WithUserDetails("mary")
     public void accountDetails_with_mary_credentials_should_return_200() throws Exception {
 
         // arrange

--- a/lab/42-security-rest/src/test/java/accounts/web/AccountControllerTests.java
+++ b/lab/42-security-rest/src/test/java/accounts/web/AccountControllerTests.java
@@ -32,7 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // - Remove @Disabled annotation from each test and run it
 // - Make sure all tests pass
 
-@AutoConfigureDataJpa
 @WebMvcTest(AccountController.class)
 @ContextConfiguration(classes = {RestWsApplication.class, RestSecurityConfig.class})
 public class AccountControllerTests {

--- a/lab/build.gradle
+++ b/lab/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-
 }
 
 plugins {
@@ -28,9 +27,9 @@ subprojects {
     apply plugin: "io.spring.dependency-management"
 
     repositories {
-        maven {
-            url = 'https://repo.maven.apache.org/maven2'
-        }
+        mavenCentral()
+        maven { url 'https://repo.spring.io/milestone' }
+        maven { url 'https://repo.spring.io/snapshot' }
     }
 
     dependencyManagement {
@@ -38,7 +37,9 @@ subprojects {
             mavenBom("org.springframework.boot:spring-boot-dependencies:$springBootVersion")
         }
     }
-
+    
+    ext['spring-security.version'] = '5.8.0-RC1'
+    
     dependencies {
         implementation "org.springframework.boot:spring-boot-starter"
         implementation "org.springframework.boot:spring-boot-starter-jdbc"

--- a/lab/pom.xml
+++ b/lab/pom.xml
@@ -18,6 +18,7 @@
         <easymock.version>4.3</easymock.version>
         <hibernate.jmx.version>3.5.6-Final</hibernate.jmx.version>
         <jamon.version>2.82</jamon.version>
+        <spring-security.version>5.8.0-RC1</spring-security.version>
 
         <java.version>11</java.version>
 
@@ -160,6 +161,45 @@
             </plugin>
         </plugins>
     </build>
+    
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+    </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    
     <modules>
         <!--
           // KEEP IN SYNC WITH SLIDES
@@ -176,10 +216,10 @@
         <module>12-javaconfig-dependency-injection-solution</module>
         <module>16-annotations</module>
         <module>16-annotations-solution</module>
-        <module>22-aop</module>
-        <module>22-aop-solution</module>
 
         <!-- Day 2 -->
+        <module>22-aop</module>
+        <module>22-aop-solution</module>
         <module>24-test</module>
         <module>24-test-solution</module>
         <module>26-jdbc</module>
@@ -197,10 +237,10 @@
         <module>34-spring-data-jpa-solution</module>
         <module>36-mvc</module>
         <module>36-mvc-solution</module>
+        
+        <!-- Day 4 -->
         <module>38-rest-ws</module>
         <module>38-rest-ws-solution</module>
-
-        <!-- Day 4 -->
         <module>40-boot-test</module>
         <module>40-boot-test-solution</module>
         <module>42-security-rest</module>


### PR DESCRIPTION
This PR updates the Spring Security lab with the following:
- Removes the deprecated `WebSecurityConfigurerAdapter` in favor of bean definitions
- Uses lambda expressions instead of method chaining (`.and()`) in the `SecurityFilterChain`
- Uses `requestMatchers` instead of `mvcMatchers`
- Removes `@AutoConfigureDataJpa` from tests
- Uses the new `@EnableMethodSecurity`
- Fixes tests that were not effectively testing what was supposed to test
-  Updates the lab TODOs
- Refactors the `RestSecurityConfig` and splits it into 3 classes
- Some polishing